### PR TITLE
Add parentClass information to summary. Updated tests and package.json

### DIFF
--- a/lib/build-manager/artifacts/artifact.js
+++ b/lib/build-manager/artifacts/artifact.js
@@ -34,15 +34,13 @@ class Artifact {
       compiledTarball: {
         path: null,
         md5: null
-      }
+      },
+      class: null
     });
     const metadata = data.metadata;
     this.builtOn = new Date();
     this.metadata = {id: metadata.id, version: metadata.version};
-    this.prefix = data.prefix;
-    this.mainLicense = data.mainLicense;
-    this.sourceTarball = data.sourceTarball;
-    this.compiledTarball = data.compiledTarball;
+    _.extend(this, _.pick(data, ['prefix', 'mainLicense', 'sourceTarball', 'compiledTarball', 'parentClass']));
     if (!_.isEmpty(data.pick)) {
       this.pick = data.pick;
     }

--- a/lib/build-manager/artifacts/artifact.js
+++ b/lib/build-manager/artifacts/artifact.js
@@ -35,11 +35,11 @@ class Artifact {
         path: null,
         md5: null
       },
-      class: null
+      parentClass: null
     });
     const metadata = data.metadata;
     this.builtOn = new Date();
-    this.metadata = {id: metadata.id, version: metadata.version};
+    this.metadata = _.pick(metadata, ['id', 'version']);
     _.extend(this, _.pick(data, ['prefix', 'mainLicense', 'sourceTarball', 'compiledTarball', 'parentClass']));
     if (!_.isEmpty(data.pick)) {
       this.pick = data.pick;

--- a/lib/build-manager/artifacts/summary.js
+++ b/lib/build-manager/artifacts/summary.js
@@ -87,6 +87,7 @@ class Summary {
       sourceTarball: component.sourceTarball,
       mainLicense: component.mainLicense,
       pick: component.pick,
+      parentClass: Object.getPrototypeOf(component.constructor).name,
       buildTime,
       compiledTarball
     }));

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "common-utils": "bitnami/node-common-utils#v2.0.1",
     "nami-logger": "^0.0.1",
-    "nami-utils": "^0.0.1",
+    "nami-utils": "^0.1.0",
     "strftime": "^0.9.2",
     "tarball-utils": "bitnami/node-tarball-utils#v2.0.2",
     "version-utils": "bitnami/node-version-utils#v2.0.0"

--- a/test/artifact.js
+++ b/test/artifact.js
@@ -19,7 +19,8 @@ describe('Artifact', () => {
       compiledTarball: {
         path: 'compiled-test.tar.gz',
         md5: 'testmd5'
-      }
+      },
+      parentClass: 'Library'
     };
     const result = {
       metadata: {id: 'component', version: '1.0.0'},
@@ -33,7 +34,8 @@ describe('Artifact', () => {
       compiledTarball: {
         path: 'compiled-test.tar.gz',
         md5: 'testmd5'
-      }
+      },
+      parentClass: 'Library'
     };
     const artifact = new Artifact(inputObject);
     _.each(result, (v, k) => expect(artifact[k]).to.be.eql(v));

--- a/test/summary.js
+++ b/test/summary.js
@@ -228,7 +228,7 @@ describe('Summary', () => {
         if (_.isObject(v) && !_.isRegExp(v)) {
           expect(toCheck[k]).to.be.eql(v);
         } else {
-          expect(!!toCheck[k].toString().match(v), 'Malformed JSON').to.be.true; // eslint-disable-line
+          expect(!!toCheck[k].toString().match(v), 'Malformed JSON').to.be.eql(true);
         }
       });
     };

--- a/test/summary.js
+++ b/test/summary.js
@@ -79,7 +79,7 @@ describe('Summary', () => {
       },
       sourceTarball: 'test.tar.gz'
     };
-    summary.addArtifact(component, {test: 1});
+    summary.addArtifact(component);
     const artifact = summary.artifacts[0];
     _.each(component, (v, k) => {
       expect(artifact[k]).to.be.eql(v);
@@ -101,7 +101,7 @@ describe('Summary', () => {
       prefix: test.prefix,
       srcDir: test.buildDir
     };
-    summary.addArtifact(component, {test: 1});
+    summary.addArtifact(component);
     /* eslint-disable no-unused-expressions */
     expect(
       path.join(artifactsDir, `${component.metadata.id}-${component.metadata.version}-linux-x64.tar.gz`)
@@ -188,16 +188,19 @@ describe('Summary', () => {
     });
     const summary = new Summary(be);
     fs.writeFileSync(path.join(test.prefix, 'hello'), 'hello');
-    const component = {
+    class Library {}
+    class Component extends Library {}
+    const component = new Component();
+    _.extend(component, {
       metadata: {id: 'component', version: '1.0.0'},
       prefix: test.prefix,
       mainLicense: {
         type: 'BSD3',
         licenseRelativePath: 'LICENSE'
       },
-      sourceTarball: 'test.tar.gz'
-    };
-    summary.addArtifact(component, {test: 1});
+      sourceTarball: 'test.tar.gz',
+    });
+    summary.addArtifact(component);
     summary.end();
     const expectedResult = {
       'buildTime': 0,
@@ -216,7 +219,8 @@ describe('Summary', () => {
         type: 'BSD3',
         licenseRelativePath: 'LICENSE'
       },
-      'sourceTarball': 'test.tar.gz'
+      'sourceTarball': 'test.tar.gz',
+      'parentClass': 'Library'
     };
     const obtainedResult = JSON.parse(summary.toJson({test: 2}));
     const check = function(toCheck, valid) {
@@ -224,7 +228,7 @@ describe('Summary', () => {
         if (_.isObject(v) && !_.isRegExp(v)) {
           expect(toCheck[k]).to.be.eql(v);
         } else {
-          expect(!!toCheck[k].toString().match(v)).to.be.true; // eslint-disable-line no-unused-expressions
+          expect(!!toCheck[k].toString().match(v), 'Malformed JSON').to.be.true; // eslint-disable-line
         }
       });
     };
@@ -251,7 +255,7 @@ describe('Summary', () => {
       },
       sourceTarball: 'test.tar.gz'
     };
-    summary.addArtifact(component, {test: 1});
+    summary.addArtifact(component);
     summary.end();
     summary.serialize(test.buildDir);
     const md5 = crypto.createHash('md5');


### PR DESCRIPTION
Stack summary example:

```
{
    "buildTime": 152,
    "prefix": "/opt/bitnami",
    "platform": "linux-x64",
    "builtOn": "2016-10-10T15:59:23.280Z",
    "artifacts": [
        {
            "builtOn": "2016-10-10T16:02:05.815Z",
            "metadata": {
                "id": "redmine",
                "version": "3.3.0"
            },
            "prefix": "/opt/bitnami/redmine",
            "mainLicense": {
                "type": "GPL2",
                "licenseRelativePath": "doc/COPYING",
                "main": true
            },
            "sourceTarball": "/tmp/sources/redmine-3.3.0.tar.gz",
            "compiledTarball": {
                "path": "components/redmine-3.3.0-linux-x64.tar.gz",
                "md5": "9c263064b9c3d7ccd8178ddd39c06bf7"
            },
--------->  "parentClass": "RubyApplication" <---------------------
        }
    ],
    "tarball": "redmine-3.3.0-stack-linux-x64.tar.gz",
    "md5": "20a444109e5a72c66e43d282ec4bca15"
}```