### PR TITLE
Remove base-components requirement and component-type auto resolution

### DIFF
--- a/lib/build-manager/component-provider/index.js
+++ b/lib/build-manager/component-provider/index.js
@@ -208,9 +208,6 @@ class ComponentProvider {
       // Don't keep looking
       if (componentRecipeDir) return false;
     });
-    if (!componentRecipeDir) {
-      this.logger.warn(`Cannot find recipe for ${id}. The default recipe type will be applied`);
-    }
     return componentRecipeDir;
   }
 

--- a/lib/build-manager/component-provider/recipe.js
+++ b/lib/build-manager/component-provider/recipe.js
@@ -7,9 +7,6 @@ const nutil = require('nami-utils').util;
 const utils = require('common-utils');
 const Vm = require('vm');
 const Module = require('module');
-const Library = require('blacksmith-base-components').Library;
-const CompiledComponent = require('blacksmith-base-components').CompiledComponent;
-const Component = require('blacksmith-base-components').Component;
 const _ = require('nami-utils/lodash-extra');
 const Spec = require('./spec');
 
@@ -54,6 +51,9 @@ class Recipe {
         {id: this.id, version: this.metadata.version}));
     this._componentTypeCollections = options.componentTypeCollections;
     this.componentClass = this._getRecipeClass(options.path, options.requirements);
+    if (!this.componentClass) {
+      throw new Error(`Not found a recipe for ${id}`);
+    }
   }
 
   /**
@@ -106,26 +106,13 @@ class Recipe {
   }
 
   _getRecipeClass(recipeDir, requirements) {
-    let componentClass = Component;
+    let componentClass = null;
     // Is not mandatory to have a recipe class, it could be just a base one
     if (!_.isEmpty(recipeDir)) {
       const compilationDir = nfile.exists(nfile.join(recipeDir, 'compilation')) ?
       nfile.join(recipeDir, 'compilation') : recipeDir;
       const jsFile = nfile.join(compilationDir, 'index.js');
-      if (!nfile.exists(jsFile)) {
-        const kind = nfile.basename(nfile.dirname(recipeDir));
-        switch (kind) {
-          case 'libraries':
-            componentClass = Library;
-            break;
-          case 'frameworks':
-          case 'applications':
-            componentClass = CompiledComponent;
-            break;
-          default:
-            componentClass = Component;
-        }
-      } else {
+      if (nfile.exists(jsFile)) {
         const result = this._loadRecipeJS(jsFile);
         // the loaded JS module can return either:
         // a class: OpenSSL

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "nami-utils": "^0.1.0",
     "strftime": "^0.9.2",
     "tarball-utils": "bitnami/node-tarball-utils#v2.0.3",
-    "version-utils": "bitnami/node-version-utils#v2.0.0",
-    "blacksmith-base-components": "bitnami/blacksmith-base-components#v0.0.12"
+    "version-utils": "bitnami/node-version-utils#v2.0.0"
   },
   "devDependencies": {
     "eslint": "^2.11.1",
@@ -35,7 +34,8 @@
     "mocha": "^3.0.2",
     "nock": "^8.0.0",
     "gulp": "^3.9.1",
-    "bitnami-gulp-common-tasks": "bitnami/gulp-common-tasks#v2.0.4"
+    "bitnami-gulp-common-tasks": "bitnami/gulp-common-tasks#v2.0.4",
+    "blacksmith-base-components": "bitnami/blacksmith-base-components#v0.0.12"
   },
   "optionalDependencies": {
     "anvil-client": "0.0.3"


### PR DESCRIPTION
Component-type auto resolution can lead to unexpected errors and assumptions that may be false. This will leave the responsability of the component types to load just to the configuration owner.