### PR TITLE
Adapt to Anvil changes. Reorder Anvil related tests

### DIFF
--- a/lib/build-manager/component-provider/index.js
+++ b/lib/build-manager/component-provider/index.js
@@ -59,7 +59,8 @@ class ComponentProvider {
   getRecipe(id, requirements) {
     return new Recipe(id, this.recipeDirectories, this.componentTypeCollections, {
       requirements,
-      logger: this.logger
+      logger: this.logger,
+      metadataServer: this.metadataServer
     });
   }
 

--- a/lib/build-manager/component-provider/recipe.js
+++ b/lib/build-manager/component-provider/recipe.js
@@ -39,11 +39,12 @@ const Logger = require('nami-logger');
 class Recipe {
   constructor(id, recipeDirectories, componentTypeCollections, options) {
     options = _.defaults(options || {}, {
-      metadataServer: {endPoint: null, prioritize: false},
+      metadataServer: {client: null, prioritize: false},
       requirements: {},
       logger: new Logger({level: 'silent'})
     });
     this.logger = options.logger;
+    this.metadataServer = options.metadataServer;
     this._recipeDirectories = _.flatten([recipeDirectories]);
     const recipeDir = this._findRecipeFile(id, this._recipeDirectories);
     const requirements = options.requirements || {};
@@ -87,7 +88,7 @@ class Recipe {
       licenses: _.map(versionInfo.licenses, lic => {
         return {
           type: lic.name,
-          licenseRelativePath: lic.relative_license_path,
+          licenseRelativePath: lic.license_relative_path,
           licenseUrl: lic.url,
           main: lic.main
         };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "^2.11.1",
     "eslint-config-bitnami": "bitnami/eslint-config-bitnami#v1.0.0",
     "eslint-plugin-import": "^1.8.1",
-    "blacksmith-test": "bitnami/blacksmith-test#v0.0.9",
+    "blacksmith-test": "bitnami/blacksmith-test#v0.0.10",
     "chai": "^3.2.0",
     "chai-fs": "git+https://github.com/bitnami/chai-fs.git",
     "chai-subset": "^1.1.0",
@@ -38,7 +38,7 @@
     "blacksmith-base-components": "bitnami/blacksmith-base-components#v0.0.12"
   },
   "optionalDependencies": {
-    "anvil-client": "0.0.3"
+    "anvil-client": "0.0.5"
   },
   "keywords": [
     "blacksmith"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "^2.11.1",
     "eslint-config-bitnami": "bitnami/eslint-config-bitnami#v1.0.0",
     "eslint-plugin-import": "^1.8.1",
-    "blacksmith-test": "bitnami/blacksmith-test#v0.0.10",
+    "blacksmith-test": "bitnami/blacksmith-test#v0.0.12",
     "chai": "^3.2.0",
     "chai-fs": "git+https://github.com/bitnami/chai-fs.git",
     "chai-subset": "^1.1.0",


### PR DESCRIPTION
This diff includes:
 - The storage of the object `this.metadataServer` in the Recipe class that was missing (and a fix on its inputs)
 - Minor fix on the format received from the metadata server API
 - A reorder and refactor of the metadata server related tests that were misplaced since we now resolve the metadata in the Recipe class.